### PR TITLE
[Security] NACL 모듈 추가 (#27)

### DIFF
--- a/terraform/envs/dev/security/main.tf
+++ b/terraform/envs/dev/security/main.tf
@@ -98,58 +98,58 @@ module "sg_db" {
   }
 }
 
-# # =================================================
-# # 3) 네트워크 ACL (Network Access Control List)
-# # =================================================
+# =================================================
+# 3) 네트워크 ACL (Network Access Control List)
+# =================================================
 
-# # --- 3-1. Public Subnet용 NACL 생성 ---
-# # Public Subnet은 외부 인터넷과 직접 통신하므로, HTTP/HTTPS 트래픽을 허용하고
-# # 응답 트래픽을 위한 임시 포트 범위를 허용하는 규칙이 필요합니다.
-# module "nacl_public" {
-#   source = "../../../modules/nacl" # NACL 모듈 경로
+# --- 3-1. Public Subnet용 NACL 생성 ---
+# Public Subnet은 외부 인터넷과 직접 통신하므로, HTTP/HTTPS 트래픽을 허용하고
+# 응답 트래픽을 위한 임시 포트 범위를 허용하는 규칙이 필요합니다.
+module "nacl_public" {
+  source = "../../../modules/nacl" # NACL 모듈 경로
 
-#   name_prefix = "public" # NACL 이름 접두사
-#   environment = var.environment # 환경 변수 (dev, prod 등)
-#   vpc_id      = data.terraform_remote_state.network.outputs.vpc_id # network 레이어에서 가져온 VPC ID
-#   vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr # NACL 모듈 내부에서 사용할 VPC CIDR
-#   nacl_type   = "public" # Public Subnet용 NACL임을 지정
+  name_prefix = "public" # NACL 이름 접두사
+  environment = var.environment # 환경 변수 (dev, prod 등)
+  vpc_id      = data.terraform_remote_state.network.outputs.vpc_id # network 레이어에서 가져온 VPC ID
+  vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr # NACL 모듈 내부에서 사용할 VPC CIDR
+  nacl_type   = "public" # Public Subnet용 NACL임을 지정
 
-#   # Public Subnet ID 목록을 전달합니다.
-#   # network 레이어의 public_subnet_ids는 맵 형태이므로 values() 함수로 값만 추출합니다.
-#   subnet_ids = values(data.terraform_remote_state.network.outputs.public_subnet_ids)
-# }
+  # Public Subnet ID 목록을 전달합니다.
+  # network 레이어의 public_subnet_ids는 맵 형태이므로 values() 함수로 값만 추출합니다.
+  subnet_ids = values(data.terraform_remote_state.network.outputs.public_subnet_ids)
+}
 
-# # --- 3-2. Private App Subnet용 NACL 생성 ---
-# # Private App Subnet은 ALB로부터의 트래픽과 VPC 내부 서비스(DB, VPC Endpoint)와의 통신을 허용합니다.
-# # 외부 인터넷으로는 NAT Gateway를 통해 나갑니다.
-# module "nacl_private_app" {
-#   source = "../../../modules/nacl"
+# --- 3-2. Private App Subnet용 NACL 생성 ---
+# Private App Subnet은 ALB로부터의 트래픽과 VPC 내부 서비스(DB, VPC Endpoint)와의 통신을 허용합니다.
+# 외부 인터넷으로는 NAT Gateway를 통해 나갑니다.
+module "nacl_private_app" {
+  source = "../../../modules/nacl"
 
-#   name_prefix = "private-app"
-#   environment = var.environment
-#   vpc_id      = data.terraform_remote_state.network.outputs.vpc_id
-#   vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr
-#   nacl_type   = "private-app" # Private App Subnet용 NACL임을 지정
+  name_prefix = "private-app"
+  environment = var.environment
+  vpc_id      = data.terraform_remote_state.network.outputs.vpc_id
+  vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr
+  nacl_type   = "private-app" # Private App Subnet용 NACL임을 지정
 
-#   # Private App Subnet ID 목록을 전달합니다.
-#   subnet_ids = values(data.terraform_remote_state.network.outputs.private_app_subnet_ids)
-# }
+  # Private App Subnet ID 목록을 전달합니다.
+  subnet_ids = values(data.terraform_remote_state.network.outputs.private_app_subnet_ids)
+}
 
-# # --- 3-3. Private DB Subnet용 NACL 생성 ---
-# # Private DB Subnet은 Private App Subnet으로부터의 DB 트래픽만 허용하고,
-# # VPC 내부 통신 및 응답 트래픽을 허용합니다. 외부 인터넷 접근은 제한됩니다.
-# module "nacl_private_db" {
-#   source = "../../../modules/nacl"
+# --- 3-3. Private DB Subnet용 NACL 생성 ---
+# Private DB Subnet은 Private App Subnet으로부터의 DB 트래픽만 허용하고,
+# VPC 내부 통신 및 응답 트래픽을 허용합니다. 외부 인터넷 접근은 제한됩니다.
+module "nacl_private_db" {
+  source = "../../../modules/nacl"
 
-#   name_prefix = "private-db"
-#   environment = var.environment
-#   vpc_id      = data.terraform_remote_state.network.outputs.vpc_id
-#   vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr
-#   nacl_type   = "private-db" # Private DB Subnet용 NACL임을 지정
+  name_prefix = "private-db"
+  environment = var.environment
+  vpc_id      = data.terraform_remote_state.network.outputs.vpc_id
+  vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr
+  nacl_type   = "private-db" # Private DB Subnet용 NACL임을 지정
 
-#   # Private DB Subnet ID 목록을 전달합니다.
-#   subnet_ids = values(data.terraform_remote_state.network.outputs.private_db_subnet_ids)
-# }
+  # Private DB Subnet ID 목록을 전달합니다.
+  subnet_ids = values(data.terraform_remote_state.network.outputs.private_db_subnet_ids)
+}
 
 # # =================================================
 # # 4) VPC 엔드포인트 (VPC Endpoints)

--- a/terraform/envs/dev/security/main.tf
+++ b/terraform/envs/dev/security/main.tf
@@ -1,6 +1,8 @@
-# 보안 계층: IAM, 보안 그룹, VPC 엔드포인트
+# terraform/envs/dev/security/main.tf
 
+# =================================================
 # 1) IAM 사용자/그룹 (프로젝트 계정)
+# =================================================
 module "iam" {
   source = "../../../modules/iam"
 
@@ -10,3 +12,211 @@ module "iam" {
   # Phase 1: 모두가 AdministratorAccess, phase 2할때 각 역할별 정책 적용 후, true로 적용하면 됨.
 }
 
+
+# =================================================
+# 2) 보안 그룹 (Security Groups)
+# =================================================
+
+# --- 데이터 소스: 다른 레이어의 상태 파일 읽어오기 ---
+# data "terraform_remote_state" 블록은 다른 디렉토리에서 실행된 Terraform의
+# 상태 파일(terraform.tfstate)을 읽어와서 그 안의 출력(outputs) 값을 사용할 수 있게 해줍니다.
+# 여기서는 'network' 레이어에서 생성한 VPC의 정보를 가져오기 위해 사용합니다.
+data "terraform_remote_state" "network" {
+  backend = "s3"
+  config = {
+    bucket  = "petclinic-tfstate-team-jungsu-kopo"
+    key     = "dev/yeonghyeon/network/terraform.tfstate" 
+    region  = "ap-northeast-2"
+    profile = var.network_state_profile # 변경 이유: 'profile' 인자를 하드코딩된 값 대신 'var.network_state_profile' 변수로 변경하여 환경별 프로필 설정을 유연하게 관리하고, 'terraform plan' 실행 시 발생했던 'failed to get shared config profile' 에러를 해결합니다。
+  }
+}
+
+
+# --- 보안 그룹 생성: 모듈을 여러 번 호출하는 이유 ---
+# 우리 애플리케이션은 ALB, App, DB 라는 3개의 주요 계층(Tier)으로 구성됩니다.
+# 각 계층은 서로 다른 보안 규칙을 가져야 합니다. (예: ALB는 외부 인터넷에, DB는 App에만 열려 있어야 함)
+# 따라서, 각 계층에 맞는 보안 그룹을 각각 하나씩, 총 3개 생성해야 합니다.
+# 'sg' 모듈은 "보안 그룹을 만드는 공장"과 같습니다. 이 공장에 "ALB용 주문서", "App용 주문서", "DB용 주문서"를
+# 각각 넣어주어, 각기 다른 사양의 보안 그룹 제품을 3개 만들어내는 것입니다.
+# 이것이 모듈을 여러 번 호출하는 이유이며, Terraform에서 권장하는 올바른 설계 방식입니다。
+
+
+# --- 2-1. ALB 보안 그룹 생성 ---
+module "sg_alb" {
+  # 사용할 모듈의 경로를 지정합니다.
+  source = "../../../modules/sg"
+
+  # 'sg' 모듈의 variables.tf에 정의된 변수들에게 값을 전달합니다.
+  sg_type     = "alb"             # "alb" 타입의 보안 그룹을 생성하도록 지정
+  name_prefix = "petclinic-dev"   # 생성될 리소스의 이름 접두사
+  vpc_id      = data.terraform_remote_state.network.outputs.vpc_id # network 레이어에서 가져온 VPC ID
+  vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr # 변경 이유: 'sg' 모듈의 'vpc_cidr' 변수가 추가됨에 따라, network 레이어에서 가져온 VPC CIDR 값을 전달합니다. 이는 'terraform plan' 실행 시 발생했던 'Missing required argument: vpc_cidr' 에러를 해결합니다。
+  
+  # 추가적인 태그를 지정합니다.
+  tags = {
+    Service = "ALB"
+  }
+}
+
+
+# --- 2-2. App (ECS) 보안 그룹 생성 ---
+module "sg_app" {
+  source = "../../../modules/sg"
+
+  sg_type     = "app"             # "app" 타입의 보안 그룹을 생성하도록 지정
+  name_prefix = "petclinic-dev"
+  vpc_id      = data.terraform_remote_state.network.outputs.vpc_id
+  vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr # 변경 이유: 'sg' 모듈의 'vpc_cidr' 변수가 추가됨에 따라, network 레이어에서 가져온 VPC CIDR 값을 전달합니다. 이는 'terraform plan' 실행 시 발생했던 'Missing required argument: vpc_cidr' 에러를 해결합니다。
+  
+  # App 보안 그룹은 ALB로부터의 트래픽을 받아야 합니다.
+  # 따라서, 'sg' 모듈의 'alb_source_security_group_id' 변수에
+  # 위에서 만든 ALB 보안 그룹의 ID (module.sg_alb.security_group_id)를 전달해줍니다.
+alb_source_security_group_id = module.sg_alb.security_group_id
+
+  tags = {
+    Service = "Application"
+  }
+}
+
+
+# --- 2-3. DB (Aurora) 보안 그룹 생성 ---
+module "sg_db" {
+  source = "../../../modules/sg"
+
+  sg_type     = "db"              # "db" 타입의 보안 그룹을 생성하도록 지정
+  name_prefix = "petclinic-dev"
+  vpc_id      = data.terraform_remote_state.network.outputs.vpc_id
+  vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr # 변경 이유: 'sg' 모듈의 'vpc_cidr' 변수가 추가됨에 따라, network 레이어에서 가져온 VPC CIDR 값을 전달합니다. 이는 'terraform plan' 실행 시 발생했던 'Missing required argument: vpc_cidr' 에러를 해결합니다。
+
+  # DB 보안 그룹은 App으로부터의 트래픽을 받아야 합니다.
+  # 'app_source_security_group_id' 변수에
+  # 위에서 만든 App 보안 그룹의 ID (module.sg_app.security_group_id)를 전달해줍니다。
+  app_source_security_group_id = module.sg_app.security_group_id
+
+  tags = {
+    Service = "Database"
+  }
+}
+
+# # =================================================
+# # 3) 네트워크 ACL (Network Access Control List)
+# # =================================================
+
+# # --- 3-1. Public Subnet용 NACL 생성 ---
+# # Public Subnet은 외부 인터넷과 직접 통신하므로, HTTP/HTTPS 트래픽을 허용하고
+# # 응답 트래픽을 위한 임시 포트 범위를 허용하는 규칙이 필요합니다.
+# module "nacl_public" {
+#   source = "../../../modules/nacl" # NACL 모듈 경로
+
+#   name_prefix = "public" # NACL 이름 접두사
+#   environment = var.environment # 환경 변수 (dev, prod 등)
+#   vpc_id      = data.terraform_remote_state.network.outputs.vpc_id # network 레이어에서 가져온 VPC ID
+#   vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr # NACL 모듈 내부에서 사용할 VPC CIDR
+#   nacl_type   = "public" # Public Subnet용 NACL임을 지정
+
+#   # Public Subnet ID 목록을 전달합니다.
+#   # network 레이어의 public_subnet_ids는 맵 형태이므로 values() 함수로 값만 추출합니다.
+#   subnet_ids = values(data.terraform_remote_state.network.outputs.public_subnet_ids)
+# }
+
+# # --- 3-2. Private App Subnet용 NACL 생성 ---
+# # Private App Subnet은 ALB로부터의 트래픽과 VPC 내부 서비스(DB, VPC Endpoint)와의 통신을 허용합니다.
+# # 외부 인터넷으로는 NAT Gateway를 통해 나갑니다.
+# module "nacl_private_app" {
+#   source = "../../../modules/nacl"
+
+#   name_prefix = "private-app"
+#   environment = var.environment
+#   vpc_id      = data.terraform_remote_state.network.outputs.vpc_id
+#   vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr
+#   nacl_type   = "private-app" # Private App Subnet용 NACL임을 지정
+
+#   # Private App Subnet ID 목록을 전달합니다.
+#   subnet_ids = values(data.terraform_remote_state.network.outputs.private_app_subnet_ids)
+# }
+
+# # --- 3-3. Private DB Subnet용 NACL 생성 ---
+# # Private DB Subnet은 Private App Subnet으로부터의 DB 트래픽만 허용하고,
+# # VPC 내부 통신 및 응답 트래픽을 허용합니다. 외부 인터넷 접근은 제한됩니다.
+# module "nacl_private_db" {
+#   source = "../../../modules/nacl"
+
+#   name_prefix = "private-db"
+#   environment = var.environment
+#   vpc_id      = data.terraform_remote_state.network.outputs.vpc_id
+#   vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr
+#   nacl_type   = "private-db" # Private DB Subnet용 NACL임을 지정
+
+#   # Private DB Subnet ID 목록을 전달합니다.
+#   subnet_ids = values(data.terraform_remote_state.network.outputs.private_db_subnet_ids)
+# }
+
+# # =================================================
+# # 4) VPC 엔드포인트 (VPC Endpoints)
+# # =================================================
+
+# # --- 현재 AWS 리전 정보 가져오기 ---
+# data "aws_region" "current" {}
+
+# # --- VPC 엔드포인트 보안 그룹 생성 ---
+# # VPC 엔드포인트는 특정 포트를 통해 AWS 서비스와 통신하므로,
+# # 이 통신을 허용하는 보안 그룹이 필요합니다.
+# module "sg_vpce" {
+#   source = "../../../modules/sg"
+
+#   sg_type     = "vpce" # "vpce" 타입의 보안 그룹을 생성하도록 지정
+#   name_prefix = var.name_prefix # 기존 name_prefix 변수 사용
+#   vpc_id      = data.terraform_remote_state.network.outputs.vpc_id
+#   vpc_cidr    = data.terraform_remote_state.network.outputs.vpc_cidr # 변경 이유: 'sg' 모듈의 'vpc_cidr' 변수가 추가됨에 따라, network 레이어에서 가져온 VPC CIDR 값을 전달합니다. 이는 'terraform plan' 실행 시 발생했던 'Missing required argument: vpc_cidr' 에러를 해결합니다。
+
+#   tags = {
+#     Service = "VPCE"
+#   }
+# }
+
+# # --- VPC 엔드포인트 모듈 호출 ---
+# # 프라이빗 서브넷에서 AWS 서비스에 안전하게 접근하기 위한 VPC 엔드포인트를 생성합니다.
+# module "endpoint" {
+#   source = "../../../modules/endpoint"
+
+#   vpc_id               = data.terraform_remote_state.network.outputs.vpc_id
+#   private_subnet_ids   = values(data.terraform_remote_state.network.outputs.private_app_subnet_ids)
+#   vpc_endpoint_sg_id   = module.sg_vpce.security_group_id
+#   aws_region           = data.aws_region.current.name
+#   project_name         = var.name_prefix # name_prefix를 project_name으로 전달
+#   environment          = var.environment
+# }
+
+# # =================================================
+# # 5) Secrets Manager (민감 정보 관리)
+# # =================================================
+
+# # --- DB 비밀번호를 위한 Secrets Manager 시크릿 생성 ---
+# # 데이터베이스 비밀번호와 같은 민감 정보를 안전하게 저장하고 관리합니다.
+# # 실제 비밀번호 값은 Terraform 코드에 직접 노출하지 않고, AWS 콘솔이나 다른 방법으로 설정합니다.
+# module "db_password_secret" {
+#   source = "../../../modules/secrets-manager"
+
+#   secret_name             = "${var.name_prefix}/dev/db-password" # 시크릿 이름: petclinic/dev/db-password
+#   secret_description      = "Database password for PetClinic application"
+#   recovery_window_in_days = 7 # 7일 후 영구 삭제 (기본 30일에서 변경)
+#   project_name            = var.name_prefix
+#   environment             = var.environment
+# }
+
+# # =================================================
+# # 6) Cognito (사용자 인증 및 권한 부여)
+# # =================================================
+
+# # --- Cognito User Pool 및 클라이언트 생성 ---
+# # 웹 및 모바일 앱에 사용자 가입, 로그인 및 액세스 제어를 제공합니다.
+# module "cognito" {
+#   source = "../../../modules/cognito"
+
+#   project_name        = var.name_prefix
+#   environment         = var.environment
+#   # 콜백 및 로그아웃 URL은 애플리케이션의 URL에 따라 달라집니다.
+#   # 현재는 개발용 기본값을 사용하며, 나중에 실제 URL로 업데이트해야 합니다.
+#   cognito_callback_urls = ["http://localhost:8080/login"] # 예시: 애플리케이션의 로그인 후 리다이렉트 URL
+#   cognito_logout_urls   = ["http://localhost:8080/logout"] # 예시: 애플리케이션의 로그아웃 후 리다이렉트 URL
+# }

--- a/terraform/envs/dev/security/providers.tf
+++ b/terraform/envs/dev/security/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.0"
+      version = "~> 5.0" # network 폴더와 버전을 맞추는 것이 안전합니다.
     }
   }
 }
@@ -17,7 +17,7 @@ provider "aws" {
     tags = {
       Project     = "petclinic"
       Environment = "dev"
-      Layer       = "security"
+      Layer       = "security" # 이 디렉토리의 역할은 'security' 입니다.
       ManagedBy   = "terraform"
       Owner       = "team-petclinic"
       CostCenter  = "training"

--- a/terraform/envs/dev/security/variables.tf
+++ b/terraform/envs/dev/security/variables.tf
@@ -7,3 +7,20 @@ variable "aws_profile" {
   description = "인증용 AWS 프로필"
   type        = string
 }
+
+variable "environment" {
+  description = "배포 환경 (예: dev, prod)"
+  type        = string
+  default     = "dev"
+}
+
+variable "name_prefix" {
+  description = "리소스 이름에 사용될 접두사"
+  type        = string
+  default     = "petclinic"
+}
+
+variable "network_state_profile" {
+  description = "프로젝트의 network 레이어 Terraform 상태를 읽어올 AWS 프로필"
+  type        = string
+}

--- a/terraform/modules/nacl/main.tf
+++ b/terraform/modules/nacl/main.tf
@@ -1,0 +1,206 @@
+# NACL (Network Access Control List) 모듈 메인 파일
+# 이 파일은 지정된 VPC에 네트워크 ACL을 생성하고 서브넷에 연결합니다.
+
+# 네트워크 ACL을 생성합니다.
+resource "aws_network_acl" "this" {
+  vpc_id = var.vpc_id # NACL이 속할 VPC의 ID
+
+  tags = {
+    Name        = "${var.name_prefix}-${var.environment}-nacl" # NACL의 이름 태그
+    Environment = var.environment                               # 환경 태그 (예: dev, prod)
+    ManagedBy   = "terraform"                                   # Terraform으로 관리됨을 명시
+  }
+}
+
+# NACL 타입에 따른 인바운드/아웃바운드 규칙을 정의합니다.
+# 이 규칙들은 'To-Be 아키텍처 인프라 설계 초안 문서.md'를 기반으로 합니다.
+locals {
+  # Public Subnet용 인바운드 규칙
+  public_ingress_rules = {
+    "http" = {
+      rule_no    = 100
+      action     = "allow"
+      protocol   = "tcp"
+      cidr_block = "0.0.0.0/0"
+      from_port  = 80
+      to_port    = 80
+    },
+    "https" = {
+      rule_no    = 110
+      action     = "allow"
+      protocol   = "tcp"
+      cidr_block = "0.0.0.0/0"
+      from_port  = 443
+      to_port    = 443
+    },
+    "ephemeral_return_traffic" = {
+      rule_no    = 120
+      action     = "allow"
+      protocol   = "tcp"
+      cidr_block = var.vpc_cidr # VPC 내부에서 시작된 응답 트래픽 허용
+      from_port  = 1024
+      to_port    = 65535
+    }
+  }
+
+  # Public Subnet용 아웃바운드 규칙
+  public_egress_rules = {
+    "all_outbound" = {
+      rule_no    = 100
+      action     = "allow"
+      protocol   = "-1"
+      cidr_block = "0.0.0.0/0"
+      from_port  = 0
+      to_port    = 0
+    }
+  }
+
+  # Private App Subnet용 인바운드 규칙
+  private_app_ingress_rules = {
+    "alb_to_app" = {
+      rule_no    = 100
+      action     = "allow"
+      protocol   = "tcp"
+      cidr_block = var.vpc_cidr # ALB가 위치한 VPC CIDR로부터의 트래픽 허용
+      from_port  = 8080
+      to_port    = 8080
+    },
+    "vpc_internal_communication" = {
+      rule_no    = 110
+      action     = "allow"
+      protocol   = "-1"
+      cidr_block = var.vpc_cidr # VPC 내부 통신 허용 (DB, VPC Endpoint 등)
+      from_port  = 0
+      to_port    = 0
+    },
+    "ephemeral_return_traffic" = {
+      rule_no    = 120
+      action     = "allow"
+      protocol   = "tcp"
+      cidr_block = "0.0.0.0/0" # 외부로 나간 트래픽에 대한 응답 허용
+      from_port  = 1024
+      to_port    = 65535
+    }
+  }
+
+  # Private App Subnet용 아웃바운드 규칙
+  private_app_egress_rules = {
+    "all_outbound" = {
+      rule_no    = 100
+      action     = "allow"
+      protocol   = "-1"
+      cidr_block = "0.0.0.0/0"
+      from_port  = 0
+      to_port    = 0
+    }
+  }
+
+  # Private DB Subnet용 인바운드 규칙
+  private_db_ingress_rules = {
+    "app_to_db" = {
+      rule_no    = 100
+      action     = "allow"
+      protocol   = "tcp"
+      cidr_block = var.vpc_cidr # Private App Subnet이 위치한 VPC CIDR로부터의 트래픽 허용
+      from_port  = 3306
+      to_port    = 3306
+    },
+    "vpc_internal_communication" = {
+      rule_no    = 110
+      action     = "allow"
+      protocol   = "-1"
+      cidr_block = var.vpc_cidr # VPC 내부 통신 허용
+      from_port  = 0
+      to_port    = 0
+    },
+    "ephemeral_return_traffic" = {
+      rule_no    = 120
+      action     = "allow"
+      protocol   = "tcp"
+      cidr_block = "0.0.0.0/0" # 외부로 나간 트래픽에 대한 응답 허용 (Egress-only IGW 등)
+      from_port  = 1024
+      to_port    = 65535
+    }
+  }
+
+  # Private DB Subnet용 아웃바운드 규칙
+  private_db_egress_rules = {
+    "all_outbound_to_vpc" = {
+      rule_no    = 100
+      action     = "allow"
+      protocol   = "-1"
+      cidr_block = var.vpc_cidr # VPC 내부로 나가는 모든 트래픽 허용
+      from_port  = 0
+      to_port    = 0
+    },
+    "ephemeral_outbound_to_internet" = {
+      rule_no    = 110
+      action     = "allow"
+      protocol   = "tcp"
+      cidr_block = "0.0.0.0/0" # Egress-only IGW를 통한 IPv6 아웃바운드 등
+      from_port  = 1024
+      to_port    = 65535
+    }
+  }
+
+  # nacl_type에 따라 선택될 규칙 세트 맵
+  all_nacl_rules = {
+    "public"      = {
+      ingress = local.public_ingress_rules
+      egress  = local.public_egress_rules
+    },
+    "private-app" = {
+      ingress = local.private_app_ingress_rules
+      egress  = local.private_app_egress_rules
+    },
+    "private-db"  = {
+      ingress = local.private_db_ingress_rules
+      egress  = local.private_db_egress_rules
+    },
+  }
+
+  # 현재 nacl_type에 해당하는 규칙 세트
+  current_nacl_rules = lookup(local.all_nacl_rules, var.nacl_type, {
+    ingress = {},
+    egress  = {}
+  })
+}
+
+# 인바운드(Ingress) 규칙을 정의합니다.
+# nacl_type에 따라 선택된 규칙 세트의 각 항목에 대해 aws_network_acl_rule 리소스를 생성합니다.
+resource "aws_network_acl_rule" "ingress" {
+  for_each = local.current_nacl_rules.ingress
+
+  network_acl_id = aws_network_acl.this.id
+  rule_number    = each.value.rule_no
+  egress         = false
+  rule_action    = each.value.action
+  protocol       = each.value.protocol
+  cidr_block     = each.value.cidr_block
+  from_port      = each.value.from_port
+  to_port        = each.value.to_port
+}
+
+# 아웃바운드(Egress) 규칙을 정의합니다.
+# nacl_type에 따라 선택된 규칙 세트의 각 항목에 대해 aws_network_acl_rule 리소스를 생성합니다.
+resource "aws_network_acl_rule" "egress" {
+  for_each = local.current_nacl_rules.egress
+
+  network_acl_id = aws_network_acl.this.id
+  rule_number    = each.value.rule_no
+  egress         = true
+  rule_action    = each.value.action
+  protocol       = each.value.protocol
+  cidr_block     = each.value.cidr_block
+  from_port      = each.value.from_port
+  to_port        = each.value.to_port
+}
+
+# NACL과 서브넷을 연결합니다.
+# subnet_ids 변수에 정의된 각 서브넷 ID에 대해 aws_network_acl_association 리소스를 생성합니다.
+resource "aws_network_acl_association" "this" {
+  for_each = toset(var.subnet_ids)
+
+  network_acl_id = aws_network_acl.this.id
+  subnet_id      = each.value
+}

--- a/terraform/modules/nacl/outputs.tf
+++ b/terraform/modules/nacl/outputs.tf
@@ -1,0 +1,7 @@
+# NACL 모듈의 출력 값들을 정의합니다.
+
+# 생성된 네트워크 ACL의 ID를 출력합니다.
+output "nacl_id" {
+  description = "생성된 네트워크 ACL의 ID입니다."
+  value       = aws_network_acl.this.id
+}

--- a/terraform/modules/nacl/variables.tf
+++ b/terraform/modules/nacl/variables.tf
@@ -1,0 +1,41 @@
+# NACL 모듈에서 사용될 변수들을 정의합니다.
+
+# NACL이 연결될 VPC의 ID 변수
+variable "vpc_id" {
+  description = "NACL이 연결될 VPC의 ID입니다."
+  type        = string
+}
+
+# NACL 규칙에서 사용할 VPC의 CIDR 블록 변수
+variable "vpc_cidr" {
+  description = "NACL 규칙에서 사용할 VPC의 CIDR 블록입니다."
+  type        = string
+}
+
+# NACL이 연결될 서브넷 ID 목록 변수
+variable "subnet_ids" {
+  description = "NACL과 연결될 서브넷 ID 목록입니다."
+  type        = list(string)
+}
+
+# 생성될 NACL 리소스의 이름에 사용될 접두사 변수 (예: public, private-app)
+variable "name_prefix" {
+  description = "NACL 리소스 이름에 사용될 접두사입니다 (예: public, private-app)."
+  type        = string
+}
+
+# 리소스 태그에 사용될 환경 정보 변수 (예: dev, prod)
+variable "environment" {
+  description = "NACL 리소스에 태그로 지정될 환경입니다 (예: dev, prod)."
+  type        = string
+}
+
+# 생성할 NACL의 타입 변수 (예: public, private-app, private-db)
+variable "nacl_type" {
+  description = "생성할 NACL의 타입입니다 (예: public, private-app, private-db)."
+  type        = string
+  validation {
+    condition     = contains(["public", "private-app", "private-db"], var.nacl_type)
+    error_message = "nacl_type은 'public', 'private-app', 'private-db' 중 하나여야 합니다."
+  }
+}

--- a/terraform/modules/sg/main.tf
+++ b/terraform/modules/sg/main.tf
@@ -1,0 +1,141 @@
+# 보안 그룹 모듈 메인 파일
+# 이 파일은 다양한 유형의 보안 그룹 (ALB, App, DB, VPCE)을 생성합니다.
+
+# 1. ALB (Application Load Balancer)용 보안 그룹
+resource "aws_security_group" "alb" {
+  # sg_type이 "alb"일 때만 이 리소스를 생성합니다.
+  count = var.sg_type == "alb" ? 1 : 0
+
+  name        = "${var.name_prefix}-alb-sg"
+  description = "ALB용 보안 그룹"
+  vpc_id      = var.vpc_id
+
+  # 인바운드 규칙: HTTP (80) 및 HTTPS (443) 트래픽을 모든 곳에서 허용
+  ingress {
+    protocol    = "tcp"
+    from_port   = 80
+    to_port     = 80
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTP from anywhere"
+  }
+  ingress {
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow HTTPS from anywhere"
+  }
+
+  # 아웃바운드 규칙: 모든 트래픽을 허용
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.tags,
+    { "Name" = "${var.name_prefix}-alb-sg" }
+  )
+}
+
+
+# 2. APP (Application / ECS)용 보안 그룹
+resource "aws_security_group" "app" {
+  # sg_type이 "app"일 때만 이 리소스를 생성합니다.
+  count = var.sg_type == "app" ? 1 : 0
+
+  name        = "${var.name_prefix}-app-sg"
+  description = "App (ECS)용 보안 그룹"
+  vpc_id      = var.vpc_id
+
+  # 인바운드 규칙: ALB 보안 그룹으로부터의 모든 트래픽을 허용
+  ingress {
+    protocol        = "-1"
+    from_port       = 0
+    to_port         = 0
+    security_groups = [var.alb_source_security_group_id]
+    description = "Allow all traffic from ALB"
+  }
+
+  # 아웃바운드 규칙: 모든 트래픽을 허용
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.tags,
+    { "Name" = "${var.name_prefix}-app-sg" }
+  )
+}
+
+
+# 3. DB (Database / Aurora)용 보안 그룹
+resource "aws_security_group" "db" {
+  # sg_type이 "db"일 때만 이 리소스를 생성합니다.
+  count = var.sg_type == "db" ? 1 : 0
+
+  name        = "${var.name_prefix}-db-sg"
+  description = "DB (Aurora)용 보안 그룹"
+  vpc_id      = var.vpc_id
+
+  # 인바운드 규칙: APP 보안 그룹으로부터의 MySQL/Aurora (3306) 트래픽만 허용
+  ingress {
+    protocol        = "tcp"
+    from_port       = 3306
+    to_port         = 3306
+    security_groups = [var.app_source_security_group_id]
+    description = "Allow MySQL/Aurora traffic from App"
+  }
+
+  # 아웃바운드 규칙: 모든 트래픽을 허용
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.tags,
+    { "Name" = "${var.name_prefix}-db-sg" }
+  )
+}
+
+
+# 4. VPCE (VPC Endpoint)용 보안 그룹
+resource "aws_security_group" "vpce" {
+  # sg_type이 "vpce"일 때만 이 리소스를 생성합니다.
+  count = var.sg_type == "vpce" ? 1 : 0
+
+  name        = "${var.name_prefix}-vpce-sg"
+  description = "VPC Endpoints용 보안 그룹"
+  vpc_id      = var.vpc_id
+
+  # 인바운드 규칙: VPC 내부에서 443 포트 (HTTPS) 트래픽을 허용
+  ingress {
+    protocol    = "tcp"
+    from_port   = 443
+    to_port     = 443
+    cidr_blocks = [var.vpc_cidr]
+    description = "Allow HTTPS from within VPC for VPCE"
+  }
+
+  # 아웃바운드 규칙: VPC 내부로의 모든 트래픽을 허용
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = [var.vpc_cidr]
+    description = "Allow all outbound traffic within VPC"
+  }
+
+  tags = merge(
+    var.tags,
+    { "Name" = "${var.name_prefix}-vpce-sg" }
+  )
+}

--- a/terraform/modules/sg/outputs.tf
+++ b/terraform/modules/sg/outputs.tf
@@ -1,0 +1,16 @@
+# 보안 그룹 모듈의 출력 값들을 정의합니다.
+
+# 생성된 보안 그룹의 ID를 출력합니다.
+output "security_group_id" {
+  description = "생성된 보안 그룹의 ID입니다."
+  
+  # sg_type 값에 따라 생성된 리소스의 ID를 조건부로 반환합니다.
+  # 팀장님의 스타일을 따라, 3항 연산자를 중첩하여 사용합니다.
+  value = var.sg_type == "alb" ? aws_security_group.alb[0].id : (
+          var.sg_type == "app" ? aws_security_group.app[0].id : (
+          var.sg_type == "db"  ? aws_security_group.db[0].id : (
+          var.sg_type == "vpce" ? aws_security_group.vpce[0].id : null
+          )
+          )
+        )
+}

--- a/terraform/modules/sg/variables.tf
+++ b/terraform/modules/sg/variables.tf
@@ -1,0 +1,48 @@
+# 보안 그룹 모듈에서 사용될 변수들을 정의합니다.
+
+# 생성할 보안 그룹의 종류를 결정하는 변수 (예: alb, app, db, vpce)
+variable "sg_type" {
+  description = "생성할 보안 그룹의 종류를 지정합니다 (예: alb, app, db, vpce)."
+  type        = string
+}
+
+# 보안 그룹 이름에 사용될 접두사 변수 (예: petclinic-dev)
+variable "name_prefix" {
+  description = "보안 그룹 이름에 사용할 접두사입니다 (예: petclinic-dev)."
+  type        = string
+}
+
+# 보안 그룹이 속할 VPC의 ID 변수
+variable "vpc_id" {
+  description = "보안 그룹이 생성될 VPC의 ID입니다."
+  type        = string
+}
+
+# DB 보안 그룹에 접근을 허용할 App 보안 그룹의 ID 변수
+# 이 변수는 sg_type이 "db"일 때만 사용됩니다.
+variable "app_source_security_group_id" {
+  description = "DB에 접근을 허용할 App 보안 그룹의 ID입니다."
+  type        = string
+  default     = null
+}
+
+# App 보안 그룹에 접근을 허용할 ALB 보안 그룹의 ID 변수
+# 이 변수는 sg_type이 "app"일 때만 사용됩니다.
+variable "alb_source_security_group_id" {
+  description = "App에 접근을 허용할 ALB 보안 그룹의 ID입니다."
+  type        = string
+  default     = null
+}
+
+# 리소스에 추가될 공통 태그를 위한 변수
+variable "tags" {
+  description = "리소스에 추가할 태그 맵입니다."
+  type        = map(string)
+  default     = {}
+}
+
+# VPC CIDR 변수
+variable "vpc_cidr" {
+  description = "VPC의 CIDR 블록입니다."
+  type        = string
+}


### PR DESCRIPTION
## 📝 작업 내용
Public, Private-App, Private-DB 서브넷 유형에 따라 각기 다른 NACL 규칙을 적용할  수 있는 재사용 가능한 Terraform 모듈을 추가

## ✅ 체크리스트
- [ ] 코드/구성 요소 실행 확인
- [ ] 관련 테스트 완료
- [ ] 보안 관련 설정 검토 (필요 시)
- [ ] 문서(README/위키) 업데이트
- [ ] Reviewer 지정 완료

